### PR TITLE
Increase read speed by reading more than 1 byte per call

### DIFF
--- a/lfsr.c
+++ b/lfsr.c
@@ -13,7 +13,7 @@ static ssize_t dev_read(struct file*, char*, size_t, loff_t*);
 static ssize_t dev_write(struct file*, const char*, size_t, loff_t*);
 static int lfsr_state(void);
 
-static struct file_operations fops = {
+static const struct file_operations fops = {
    .open = dev_open,
    .read = dev_read,
    .write = dev_write,


### PR DESCRIPTION
Reduces syscall overhead by returning multiple bytes per dev_read call. Test results on my machine:
\
\
Current version
```
$ dd if=/dev/lfsr of=/dev/zero bs=32M count=1 iflag=fullblock
1+0 records in
1+0 records out
33554432 bytes (34 MB, 32 MiB) copied, 14.3795 s, 2.3 MB/s
```
\
Modified version
```
$ dd if=/dev/lfsr of=/dev/zero bs=32M count=1 iflag=fullblock
1+0 records in
1+0 records out
33554432 bytes (34 MB, 32 MiB) copied, 0.661298 s, 50.7 MB/s
```
\
/dev/random for reference (after consuming pool)
```
$ dd if=/dev/random of=/dev/zero bs=32M count=1 iflag=fullblock
1+0 records in
1+0 records out
33554432 bytes (34 MB, 32 MiB) copied, 0.582424 s, 57.6 MB/s
```
\
(Increasing tmp buffer size provides a small speedup at the cost of increased stack usage)