### PR TITLE
Revert "Increase read speed by reading more than 1 byte per call"

### DIFF
--- a/lfsr.c
+++ b/lfsr.c
@@ -12,9 +12,8 @@ static int dev_release(struct inode*, struct file*);
 static ssize_t dev_read(struct file*, char*, size_t, loff_t*);
 static ssize_t dev_write(struct file*, const char*, size_t, loff_t*);
 static int lfsr_state(void);
-static void lfsr_fill(char*, size_t);
 
-static const struct file_operations fops = {
+static struct file_operations fops = {
    .open = dev_open,
    .read = dev_read,
    .write = dev_write,
@@ -59,36 +58,20 @@ static int dev_release(struct inode *inodep, struct file *filep) {
 }
 
 static ssize_t dev_read(struct file *filep, char *buffer, size_t len, loff_t *offset) {
-	size_t n, remaining = len;
-	char tmp[128];
+	int i, errors = 0;
+	char c = 0;
+	for(i = 0; i < 8; ++i)
+		c |= lfsr_state() << i;
 
-	while (remaining) {
-		n = min(remaining, sizeof(tmp));
+	errors = copy_to_user(buffer, &c, 1);
 
-		lfsr_fill(tmp, n);
-
-		if (copy_to_user(buffer, tmp, n))
-			return -EFAULT;
-
-		buffer += n;
-		remaining -= n;
-	}
-
-	return len;
+	return errors == 0 ? 1 : -EFAULT;
 }
 
 static int lfsr_state(void) {
 	uint8_t out = state & 1;
 	state = (state >> 1) | ((state ^ (state >> 2) ^ (state >> 27) ^ (state >> 29)) << 127);
 	return out;
-}
-
-static void lfsr_fill(char* buffer, size_t size) {
-	size_t i, j;
-
-	for (i = 0; i < size; ++i)
-		for (j = 0; j < 8; ++j)
-			buffer[i] |= lfsr_state() << j;
 }
 
 module_init(lfsr_init);


### PR DESCRIPTION
Reverts Error916/LFSR_module#1 this change remove all the random propriety of the lfsr
```
$ rngtest -c 10000 < /dev/lfs

rngtest: starting FIPS tests...
rngtest: bits received from input: 200000032
rngtest: FIPS 140-2 successes: 0
rngtest: FIPS 140-2 failures: 10000
rngtest: FIPS 140-2(2001-10-10) Monobit: 10000
rngtest: FIPS 140-2(2001-10-10) Poker: 10000
rngtest: FIPS 140-2(2001-10-10) Runs: 10000
rngtest: FIPS 140-2(2001-10-10) Long run: 10000
rngtest: FIPS 140-2(2001-10-10) Continuous run: 10000
rngtest: input channel speed: (min=115.597; avg=292.335; max=302.754)Mibits/s
rngtest: FIPS tests speed: (min=112.861; avg=368.225; max=397.364)Mibits/s
rngtest: Program run time: 1171405 microseconds
```